### PR TITLE
Add FindClientTypeCommand tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindClientTypeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindClientTypeCommand.java
@@ -37,7 +37,17 @@ public class FindClientTypeCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        return true;
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindClientTypeCommand)) {
+            return false;
+        }
+
+        FindClientTypeCommand otherFindCommand = (FindClientTypeCommand) other;
+        return predicate.equals(otherFindCommand.predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/FindClientTypeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindClientTypeCommandParser.java
@@ -25,6 +25,12 @@ public class FindClientTypeCommandParser implements Parser<FindClientTypeCommand
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindClientTypeCommand.MESSAGE_USAGE));
         }
 
+        // Check for special characters - only allow alphanumeric and whitespace
+        if (!trimmedArgs.matches("^[a-zA-Z0-9\\s]+$")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindClientTypeCommand.MESSAGE_USAGE));
+        }
+
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
         return new FindClientTypeCommand(new ClientTypeContainsKeywordsPredicate(Arrays.asList(nameKeywords)));

--- a/src/test/data/JsonSerializableClientHubTest/typicalPersonsClientHub.json
+++ b/src/test/data/JsonSerializableClientHubTest/typicalPersonsClientHub.json
@@ -5,21 +5,21 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "clientTypes" : [ "A" ],
+    "clientTypes" : [ "Investment" ],
     "description" : "A type"
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "" : [ "A", "B" ],
+    "clientTypes" : [ "Investment" ],
     "description" : "Likes to eat a lot"
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "clientTypes" : [ ],
+    "clientTypes" : [ "Investment" ],
     "description" : "Likes to eat a lot"
   }, {
     "name" : "Daniel Meier",

--- a/src/test/java/seedu/address/logic/commands/FindClientTypeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindClientTypeCommandTest.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.getTypicalClientHub;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ClientTypeContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindClientTypeCommand}.
+ */
+public class FindClientTypeCommandTest {
+    private Model model = new ModelManager(getTypicalClientHub(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalClientHub(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        ClientTypeContainsKeywordsPredicate firstPredicate =
+                new ClientTypeContainsKeywordsPredicate(List.of("Investment"));
+        ClientTypeContainsKeywordsPredicate secondPredicate =
+                new ClientTypeContainsKeywordsPredicate(List.of("Healthcare"));
+
+        FindClientTypeCommand findClientTypeFirstCommand = new FindClientTypeCommand(firstPredicate);
+        FindClientTypeCommand findClientTypeSecondCommand = new FindClientTypeCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findClientTypeFirstCommand.equals(findClientTypeFirstCommand));
+
+        // same values -> returns true
+        FindClientTypeCommand findClientTypeFirstCommandCopy = new FindClientTypeCommand(firstPredicate);
+        assertTrue(findClientTypeFirstCommand.equals(findClientTypeFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findClientTypeFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findClientTypeFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(findClientTypeFirstCommand.equals(findClientTypeSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPhoneFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        ClientTypeContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindClientTypeCommand command = new FindClientTypeCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_singleKeyword_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        ClientTypeContainsKeywordsPredicate predicate = preparePredicate("Investment");
+        FindClientTypeCommand command = new FindClientTypeCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void toStringMethod() {
+        ClientTypeContainsKeywordsPredicate predicate = new ClientTypeContainsKeywordsPredicate(List.of("Investment"));
+        FindClientTypeCommand findClientTypeCommand = new FindClientTypeCommand(predicate);
+        String expected = FindClientTypeCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, findClientTypeCommand.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private ClientTypeContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new ClientTypeContainsKeywordsPredicate(List.of(userInput));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ClientHubParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClientHubParserTest.java
@@ -19,11 +19,13 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindClientTypeCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.FindPhoneCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.ClientTypeContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PhoneBeginsWithKeywordPredicate;
@@ -96,6 +98,14 @@ public class ClientHubParserTest {
         FindPhoneCommand command = (FindPhoneCommand) parser.parseCommand(
                 FindPhoneCommand.COMMAND_WORD + " " + keyword);
         assertEquals(new FindPhoneCommand(new PhoneBeginsWithKeywordPredicate(keyword)), command);
+    }
+
+    @Test
+    public void parseCommand_findClientType() throws Exception {
+        String keyword = "Investment";
+        FindClientTypeCommand command = (FindClientTypeCommand) parser.parseCommand(
+                FindClientTypeCommand.COMMAND_WORD + " " + keyword);
+        assertEquals(new FindClientTypeCommand(new ClientTypeContainsKeywordsPredicate(List.of(keyword))), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindClientTypeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindClientTypeCommandParserTest.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindClientTypeCommand;
+import seedu.address.model.person.ClientTypeContainsKeywordsPredicate;
+
+public class FindClientTypeCommandParserTest {
+
+    private FindClientTypeCommandParser parser = new FindClientTypeCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindClientTypeCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindClientTypeCommand() {
+        // no leading and trailing whitespaces
+        FindClientTypeCommand expectedFindClientTypeCommand =
+                new FindClientTypeCommand(new ClientTypeContainsKeywordsPredicate(List.of("Investment")));
+        assertParseSuccess(parser, "Investment", expectedFindClientTypeCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // No inputs
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindClientTypeCommand.MESSAGE_USAGE));
+
+
+        // Special Characters
+        assertParseFailure(parser, "$12",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindClientTypeCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/ClientTypeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/ClientTypeContainsKeywordsPredicateTest.java
@@ -1,0 +1,93 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class ClientTypeContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        // Initialising the Predicate Keyword list
+        String firstPredicateKeyword = "Investment";
+        String secondPredicateKeyword = "Healthcare";
+        List<String> firstPredicateKeywordList = new ArrayList<>();
+        List<String> secondPredicateKeywordList = new ArrayList<>();
+        firstPredicateKeywordList.add(firstPredicateKeyword);
+        secondPredicateKeywordList.add(secondPredicateKeyword);
+
+        ClientTypeContainsKeywordsPredicate firstPredicate =
+                new ClientTypeContainsKeywordsPredicate(firstPredicateKeywordList);
+        ClientTypeContainsKeywordsPredicate secondPredicate =
+                new ClientTypeContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ClientTypeContainsKeywordsPredicate firstPredicateCopy =
+                new ClientTypeContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_clientTypeBeginsWithKeyword_returnsTrue() {
+        // One letter
+        ClientTypeContainsKeywordsPredicate predicate = new ClientTypeContainsKeywordsPredicate(List.of("I"));
+        assertTrue(predicate.test(new PersonBuilder().withClientTypes("Investment").build()));
+
+        // Multiple letters
+        predicate = new ClientTypeContainsKeywordsPredicate(List.of("Invest"));
+        assertTrue(predicate.test(new PersonBuilder().withClientTypes("Investment").build()));
+
+        // Only one matching keyword
+        predicate = new ClientTypeContainsKeywordsPredicate(List.of("Investment"));
+        assertTrue(predicate.test(new PersonBuilder().withClientTypes("Investment").build()));
+    }
+
+    @Test
+    public void test_clientTypeDoesNotBeginWithKeyword_returnsFalse() {
+        // Zero keyword
+        ClientTypeContainsKeywordsPredicate predicate = new ClientTypeContainsKeywordsPredicate(new ArrayList<>());
+        assertFalse(predicate.test(new PersonBuilder().withClientTypes("Investment").build()));
+
+        // Non-matching keyword
+        predicate = new ClientTypeContainsKeywordsPredicate(List.of("Invistment"));
+        assertFalse(predicate.test(new PersonBuilder().withClientTypes("Investment").build()));
+
+        // Keywords match phone, email and address, but does not match ClientType
+        predicate = new ClientTypeContainsKeywordsPredicate(
+                Arrays.asList("Alice", "12345", "alice@email.com", "Main", "Street")
+        );
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withClientTypes("Investment").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "Investment";
+        ClientTypeContainsKeywordsPredicate predicate = new ClientTypeContainsKeywordsPredicate(List.of(keyword));
+
+        String expected = ClientTypeContainsKeywordsPredicate
+                .class
+                .getCanonicalName() + "{keywords=" + List.of(keyword) + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -28,13 +28,17 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
-            .withClientTypes("A")
+            .withClientTypes("Investment")
             .withDescription("A type").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432").build();
+            .withEmail("johnd@example.com")
+            .withPhone("98765432")
+            .withClientTypes("Investment").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com")
+            .withAddress("wall street")
+            .withClientTypes("Investment").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withClientTypes("B").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")


### PR DESCRIPTION
#THINGS DONE

- Add tests for FindClientTypeCommand, FindClientTypeCommandParser and ClientTypeContainsKeywordsPredicateTest.
- Modified ALICE, BENSON and CARL in TypicalPersons to add clienttypes to their attribute which I used for the tests.