### PR TITLE
Refine FindClientTypeCommand

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -21,6 +21,8 @@ public class Messages {
     public static final String MESSAGE_PERSON_NOT_FOUND = "The person cannot be found in the clientHub";
     public static final String MESSAGE_VAGUE_DELETE = "Please be more specific in the name";
     public static final String MESSAGE_PERSON_LISTED_OVERVIEW_FOR_VIEW = "%1$d person found for viewing!";
+    public static final String MESSAGE_NO_PERSON_FOUND_FOR_VIEW =
+            "No clients found please use the list command to see all clients";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/FindClientTypeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindClientTypeCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.ClientTypeContainsKeywordsPredicate;
 
@@ -20,6 +21,7 @@ public class FindClientTypeCommand extends Command {
             + "Parameters: CLIENT_TYPE [MORE_CLIENT_TYPES]...\n"
             + "Example: " + COMMAND_WORD + "Investment Plan 1";
 
+
     private final ClientTypeContainsKeywordsPredicate predicate;
 
     public FindClientTypeCommand(ClientTypeContainsKeywordsPredicate predicate) {
@@ -28,9 +30,16 @@ public class FindClientTypeCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+
+        // Check if there is anyone in the filtered list
+        if (model.getDisplayPersons().isEmpty()) {
+            throw new CommandException(
+                    String.format(Messages.MESSAGE_NO_PERSON_FOUND_FOR_VIEW)
+            );
+        }
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getDisplayPersons().size()));
     }

--- a/src/main/java/seedu/address/model/person/ClientTypeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ClientTypeContainsKeywordsPredicate.java
@@ -1,8 +1,10 @@
 package seedu.address.model.person;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.clienttype.ClientType;
@@ -26,10 +28,31 @@ public class ClientTypeContainsKeywordsPredicate implements Predicate<Person> {
             return false;
         }
 
+        // Try matching the combined phrase first
+        String combinedPhrase = String.join(" ", keywords).toLowerCase();
+        if (personClientTypes.stream().anyMatch(clientType ->
+                clientType.clientTypeName.toLowerCase().contains(combinedPhrase))) {
+            return true;
+        }
+
+        // Split each client type into individual words and flatten into a single stream of words
+        Set<String> clientTypeWords = personClientTypes.stream()
+                .map(clientType -> clientType.clientTypeName.toLowerCase().split("\\s+"))
+                .flatMap(Arrays::stream)
+                .collect(Collectors.toSet());
+
+        // Check if all keywords match at least one of the client type words
         return keywords.stream()
-                .allMatch(keyword -> personClientTypes.stream().anyMatch(clientType ->
-                        clientType.clientTypeName.toLowerCase().startsWith(keyword.toLowerCase()))
-                );
+                .allMatch(keyword -> clientTypeWords.stream()
+                        .anyMatch(word -> word.startsWith(keyword.toLowerCase())));
+
+
+
+    //        // If combined phrase does not match, try matching individual keywords
+    //        return keywords.stream()
+    //                .allMatch(keyword -> personClientTypes.stream().anyMatch(clientType ->
+    //                        clientType.clientTypeName.toLowerCase().startsWith(keyword.toLowerCase()))
+    //                );
     }
 
     @Override

--- a/src/test/data/JsonSerializableClientHubTest/typicalPersonsClientHub.json
+++ b/src/test/data/JsonSerializableClientHubTest/typicalPersonsClientHub.json
@@ -12,14 +12,14 @@
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "clientTypes" : [ "Investment" ],
+    "clientTypes" : [ "Investment", "Savings" ],
     "description" : "Likes to eat a lot"
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "clientTypes" : [ "Investment" ],
+    "clientTypes" : [ "Investment", "Healthcare" ],
     "description" : "Likes to eat a lot"
   }, {
     "name" : "Daniel Meier",

--- a/src/test/java/seedu/address/logic/commands/FindClientTypeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindClientTypeCommandTest.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_NO_PERSON_FOUND_FOR_VIEW;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailureWithNewList;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -11,7 +13,6 @@ import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.getTypicalClientHub;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -56,17 +57,16 @@ public class FindClientTypeCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPhoneFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        ClientTypeContainsKeywordsPredicate predicate = preparePredicate(" ");
+    public void execute_zeroKeywords_noClientFound() {
+        String expectedMessage = String.format(MESSAGE_NO_PERSON_FOUND_FOR_VIEW);
+        String userInput = "  ";
+        ClientTypeContainsKeywordsPredicate predicate = preparePredicate(userInput);
         FindClientTypeCommand command = new FindClientTypeCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getDisplayPersons());
+        assertCommandFailureWithNewList(command, userInput, model, expectedMessage);
     }
 
     @Test
-    public void execute_singleKeyword_multiplePersonsFound() {
+    public void execute_singleKeyword_multipleClientsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         ClientTypeContainsKeywordsPredicate predicate = preparePredicate("Investment");
         FindClientTypeCommand command = new FindClientTypeCommand(predicate);
@@ -74,6 +74,48 @@ public class FindClientTypeCommandTest {
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE, BENSON, CARL), model.getDisplayPersons());
     }
+
+    @Test
+    public void execute_caseInsensitiveKeyword_multipleClientsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        ClientTypeContainsKeywordsPredicate predicate = preparePredicate("inVeStMeNt");
+        FindClientTypeCommand command = new FindClientTypeCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL), model.getDisplayPersons());
+    }
+
+    @Test
+    public void execute_multipleMatchingKeywords_singleClientFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        ClientTypeContainsKeywordsPredicate predicate = preparePredicate("Investment Healthcare");
+        FindClientTypeCommand command = new FindClientTypeCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getDisplayPersons());
+    }
+
+    @Test
+    public void execute_secondWordMatch_returnsCorrectClient() {
+        // Should match person with client type "Investment Plan" when searching just "Plan"
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        ClientTypeContainsKeywordsPredicate predicate = preparePredicate("Savings");
+        FindClientTypeCommand command = new FindClientTypeCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON), model.getDisplayPersons());
+    }
+
+    //    @Test
+    //    public void execute_multipleKeywordsMatchingSingleClientType_singleClientFound() {
+    //        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+    //        ClientTypeContainsKeywordsPredicate predicate = preparePredicate("Insurance Plan");
+    //        FindClientTypeCommand command = new FindClientTypeCommand(predicate);
+    //        expectedModel.updateFilteredPersonList(predicate);
+    //        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    //        assertEquals(Arrays.asList(HARRY), model.getDisplayPersons());
+    //    }
+
 
     @Test
     public void toStringMethod() {
@@ -87,6 +129,7 @@ public class FindClientTypeCommandTest {
      * Parses {@code userInput} into a {@code ClientTypeContainsKeywordsPredicate}.
      */
     private ClientTypeContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new ClientTypeContainsKeywordsPredicate(List.of(userInput));
+        String[] keywords = userInput.split("\\s+");
+        return new ClientTypeContainsKeywordsPredicate(List.of(keywords));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -34,13 +34,15 @@ public class TypicalPersons {
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com")
             .withPhone("98765432")
-            .withClientTypes("Investment").build();
+            .withClientTypes("Investment", "Savings").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com")
             .withAddress("wall street")
-            .withClientTypes("Investment").build();
+            .withClientTypes("Investment", "Healthcare").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withClientTypes("B").build();
+            .withEmail("cornelia@example.com")
+            .withAddress("10th street")
+            .withClientTypes("B").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
@@ -50,11 +52,16 @@ public class TypicalPersons {
     public static final Person ALICEY = new PersonBuilder().withName("Alice Potter").withPhone("9992442")
             .withEmail("APotter@example.com").withAddress("china").build();
 
+
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
             .withEmail("stefan@example.com").withAddress("little india").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withAddress("chicago ave").build();
+    public static final Person HARRY = new PersonBuilder().withName("Harry Potter").withPhone("9992442")
+            .withEmail("harry@example.com")
+            .withAddress("china")
+            .withClientTypes("Insurance Plan").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)


### PR DESCRIPTION
# Things done

* Search algorithm for FindClientType is more neat.
For example, if a client has client type: "Insurance Plan" doing "fc Insurance Plan" will now return the client. Doing "fc Insur Plan" will also return the client.

* Previously the search algorithm converts the client types of a person into a stream and checks if all keywords match any of the prefix of the client types. (eg. a client type of "Insurance Plan" is considered one word")

* Now, the search will first combine the keyword if there is more than 1 keyword (eg. "Insurance Plan"). If there is a matching client type, returns the client.

* If not, it will do the usual algorithm by checking if all keywords match any of the prefix of the client types. Difference is that now, it also checks the individual word within the Client type itself. (eg. client type of Insurance Plan will be split into Insurance and Plan separately)

* Add new and update test cases for FindClientType

close #143,  close #167 