### PR TITLE
Refine AddCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -59,6 +59,8 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+
+
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -23,7 +23,7 @@ public class AddCommand extends Command {
 
     public static final String SHORT_COMMAND_WORD = "a";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to ClientHub.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -23,14 +23,14 @@ public class AddCommand extends Command {
 
     public static final String SHORT_COMMAND_WORD = "a";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_CLIENT_TYPE + "CLIENT_TYPE]...\n"
-            + PREFIX_DESCRIPTION + "DESCRIPTION\n"
+            + PREFIX_DESCRIPTION + "DESCRIPTION "
+            + PREFIX_CLIENT_TYPE + "CLIENT_TYPE...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -9,8 +9,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -28,6 +28,20 @@ import seedu.address.model.reminder.Reminder;
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
+    private static final String MESSAGE_MISSING_FIELD = "The following field is missing: %s";
+    private static final String MESSAGE_MULTIPLE_MISSING_FIELDS = "The following fields are missing: %s";
+
+    // Map to store prefix to field description mapping
+    private static final HashMap<Prefix, String> FIELD_DESCRIPTIONS = new HashMap<>();
+    static {
+        FIELD_DESCRIPTIONS.put(PREFIX_NAME, "NAME");
+        FIELD_DESCRIPTIONS.put(PREFIX_PHONE, "PHONE");
+        FIELD_DESCRIPTIONS.put(PREFIX_EMAIL, "EMAIL");
+        FIELD_DESCRIPTIONS.put(PREFIX_ADDRESS, "ADDRESS");
+        FIELD_DESCRIPTIONS.put(PREFIX_CLIENT_TYPE, "CLIENT_TYPE");
+        FIELD_DESCRIPTIONS.put(PREFIX_DESCRIPTION, "DESCRIPTION");
+    }
+
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
@@ -38,10 +52,12 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_CLIENT_TYPE, PREFIX_DESCRIPTION);
 
-        // To check if fields are input correctly
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE,
-                PREFIX_EMAIL, PREFIX_CLIENT_TYPE, PREFIX_DESCRIPTION)
-                || !argMultimap.getPreamble().isEmpty()) {
+        // Check for missing fields
+        arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE,
+                PREFIX_EMAIL, PREFIX_CLIENT_TYPE, PREFIX_DESCRIPTION);
+
+        // Only check for preamble if there are no missing fields
+        if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
@@ -63,8 +79,32 @@ public class AddCommandParser implements Parser<AddCommand> {
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
      * {@code ArgumentMultimap}.
      */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    private static void arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes)
+            throws ParseException {
+        //return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+
+        StringBuilder missingFields = new StringBuilder();
+
+        for (Prefix prefix : prefixes) {
+            if (prefix == PREFIX_CLIENT_TYPE) {
+                if (argumentMultimap.getAllValues(prefix).isEmpty()) {
+                    missingFields.append(String.format("%s%s ",
+                            prefix.getPrefix(), FIELD_DESCRIPTIONS.get(prefix)));
+                }
+            } else if (!argumentMultimap.getValue(prefix).isPresent()) {
+                missingFields.append(String.format("%s%s ",
+                        prefix.getPrefix(), FIELD_DESCRIPTIONS.get(prefix)));
+            }
+        }
+
+        // If any fields are missing, throw exception with specific message
+        if (missingFields.length() > 0) {
+            String missingFieldsStr = missingFields.toString().trim();
+            String message = missingFieldsStr.contains(" ")
+                    ? String.format(MESSAGE_MULTIPLE_MISSING_FIELDS, missingFieldsStr)
+                    : String.format(MESSAGE_MISSING_FIELD, missingFieldsStr);
+            throw new ParseException(message);
+        }
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,7 +16,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[a-zA-Z()]+[a-zA-Z()\\s]*$";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z()/]+[a-zA-Z()/\\s]*$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -56,7 +56,11 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+
+        // Compare the full name of the person
+        // John Doe will match john doe
+        // To prevent duplicate names from getting added.
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -24,6 +24,7 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_CLIENT_TYPE_A;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_CLIENT_TYPE_B;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_A;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_B;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
@@ -151,36 +152,42 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + CLIENT_TYPE_DESC_A
+                        + DESCRIPTION_DESC_A + VALID_NAME_BOB,
+                "The following field is missing: n/NAME");
 
         // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB
+                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + CLIENT_TYPE_DESC_A + DESCRIPTION_DESC_A,
+                "The following field is missing: p/PHONE");
 
         // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB
+                        + ADDRESS_DESC_BOB + CLIENT_TYPE_DESC_A + DESCRIPTION_DESC_A,
+                "The following field is missing: e/EMAIL");
 
         // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                        + VALID_ADDRESS_BOB + CLIENT_TYPE_DESC_A + DESCRIPTION_DESC_A,
+                "The following field is missing: a/ADDRESS");
 
         // missing description prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                        + ADDRESS_DESC_BOB + CLIENT_TYPE_DESC_A + VALID_DESCRIPTION_A,
+                "The following field is missing: d/DESCRIPTION");
 
         // missing client type prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + VALID_DESCRIPTION_B, expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                        + ADDRESS_DESC_BOB + VALID_CLIENT_TYPE_A + DESCRIPTION_DESC_A,
+                "The following field is missing: c/CLIENT_TYPE");
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB
-                + VALID_DESCRIPTION_B,
-                expectedMessage);
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB
+                        + VALID_ADDRESS_BOB + VALID_CLIENT_TYPE_A + VALID_DESCRIPTION_A,
+                "The following fields are missing: n/NAME a/ADDRESS p/PHONE "
+                        + "e/EMAIL c/CLIENT_TYPE d/DESCRIPTION");
     }
 
     @Test
@@ -213,8 +220,8 @@ public class AddCommandParserTest {
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + INVALID_ADDRESS_DESC + VALID_CLIENT_TYPE_A + DESCRIPTION_DESC_B,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+                        + INVALID_ADDRESS_DESC + CLIENT_TYPE_DESC_A + DESCRIPTION_DESC_B,
+                Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -29,6 +29,10 @@ public class PersonTest {
         // same object -> returns true
         assertTrue(ALICE.isSamePerson(ALICE));
 
+        // name differs in case, all other attributes same -> returns true (case insensitive)
+        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        assertTrue(BOB.isSamePerson(editedBob));
+
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
@@ -40,10 +44,6 @@ public class PersonTest {
         // different name, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
-
-        // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";


### PR DESCRIPTION
# Things done

* Add customised error messages based on the input fields that are
missing.
* Refine error message
* Make some changes to the test cases in AddCommandParserTest.
* Add "/" into the REGEX constraints for the Name field. 
  * Now user can add names that have "/" in it. (eg. Bob S/O Krishnan)
* Modify the equals command in Person such that ignores all cases when checking the name of the person.
  * For eg. `John Doe` and `john doe` will be considered the same person since they are the same name.

close #205 , close #206, close #229