### PR TITLE
Fix view bugs

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -19,7 +19,7 @@ public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
     public static final String SHORT_COMMAND_WORD = "v";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a view of the specified client whose name"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a view of the specified client whose name "
             + "contain any of "
             + "the specified keywords (case-insensitive) and display them as a popup modal.\n"
             + "Parameters: NAME\n"

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -188,12 +188,10 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private void handleView() {
-        viewPersonWindow = new ViewPersonWindow(logic.getPersonList());
-        if (!viewPersonWindow.isViewShowing()) {
-            viewPersonWindow.show();
-        } else {
-            viewPersonWindow.focus();
+        if (viewPersonWindow == null) {
+            viewPersonWindow = new ViewPersonWindow(logic.getPersonList());
         }
+        viewPersonWindow.showPerson();
     }
 
     public PersonListPanel getPersonListPanel() {

--- a/src/main/java/seedu/address/ui/ViewPersonWindow.java
+++ b/src/main/java/seedu/address/ui/ViewPersonWindow.java
@@ -43,10 +43,17 @@ public class ViewPersonWindow extends UiPart<Stage> {
     public ViewPersonWindow(ObservableList<Person> person) {
         super(FXML, new Stage());
         this.person = person;
+    }
 
-        // Initialising values for the client
-        // Using streams to get the first person and set values
-        person.stream()
+    /**
+     * Updates the window to display the first person in the list.
+     */
+    private void updatePersonDisplay() {
+        // Clear existing client types
+        clientTypes.getChildren().clear();
+
+        // Update with first person's details
+        this.person.stream()
                 .findFirst()
                 .ifPresent(p -> {
                     name.setText(p.getName().fullName);
@@ -64,8 +71,22 @@ public class ViewPersonWindow extends UiPart<Stage> {
      */
     public void show() {
         LOGGER.fine("Viewing client details.");
+        updatePersonDisplay();
         getRoot().show();
         getRoot().centerOnScreen();
+
+    }
+
+    /**
+     * Updates and shows the window with details of the specified person.
+     */
+    public void showPerson() {
+        updatePersonDisplay();
+        if (!isViewShowing()) {
+            show();
+        } else {
+            focus();
+        }
     }
 
     public boolean isViewShowing() {


### PR DESCRIPTION
# Things done

* View command was implemented in v1.5. (in commit 329490a)
  * Stated behavior was that it will only show a single view person popup.
  * However, due to a small bug in one of the logic, it create a new view popup every time the view command is called.
  * Did not add any new functionalities to `view` and **only** fix that part of the code.

* Add whitespace between "name" and "contain" in the error message of a invalid `view` command.
  * Did not enhance or add anything new to the error message.

close #323 , close #311 